### PR TITLE
Add light mode toggle and improve responsive layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Routes, Route, useLocation } from 'react-router-dom';
 import Header from './components/Header';
 import Footer from './components/Footer';
@@ -25,11 +25,53 @@ const ScrollToTop = () => {
   return null;
 };
 
+const getInitialTheme = () => {
+  if (typeof window === 'undefined') {
+    return 'dark';
+  }
+
+  let preferred = 'dark';
+
+  try {
+    const stored = window.localStorage.getItem('theme');
+    if (stored === 'light' || stored === 'dark') {
+      preferred = stored;
+    } else if (typeof window.matchMedia === 'function') {
+      preferred = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+    }
+  } catch (error) {
+    if (typeof window.matchMedia === 'function') {
+      preferred = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+    }
+  }
+
+  if (typeof document !== 'undefined') {
+    document.body.dataset.theme = preferred;
+  }
+
+  return preferred;
+};
+
 const App = () => {
+  const [theme, setTheme] = useState(getInitialTheme);
+
+  useEffect(() => {
+    document.body.dataset.theme = theme;
+    try {
+      window.localStorage.setItem('theme', theme);
+    } catch (error) {
+      // ignore write errors
+    }
+  }, [theme]);
+
+  const handleToggleTheme = () => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
   return (
     <div className="app">
       <ScrollToTop />
-      <Header messengerUrl={messengerLink} />
+      <Header messengerUrl={messengerLink} theme={theme} onToggleTheme={handleToggleTheme} />
       <main>
         <Routes>
           <Route path="/" element={<Home properties={propertiesData.slice(0, 3)} messengerUrl={messengerLink} />} />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,23 +1,75 @@
-import { NavLink } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { NavLink, useLocation } from 'react-router-dom';
 
-const Header = ({ messengerUrl }) => {
+const navLinks = [
+  { to: '/', label: 'Home', end: true },
+  { to: '/listings', label: 'Listings' },
+  { to: '/about', label: 'About' },
+  { to: '/contact', label: 'Contact' },
+];
+
+const Header = ({ messengerUrl, theme, onToggleTheme }) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location.pathname]);
+
   return (
     <header>
       <div className="header-inner">
         <NavLink to="/" className="brand">
           Nacar Family Realty
         </NavLink>
-        <nav>
-          <NavLink to="/" end>
-            Home
-          </NavLink>
-          <NavLink to="/listings">Listings</NavLink>
-          <NavLink to="/about">About</NavLink>
-          <NavLink to="/contact">Contact</NavLink>
+        <nav className="nav-links">
+          {navLinks.map(({ to, label, end }) => (
+            <NavLink key={to} to={to} end={end}>
+              {label}
+            </NavLink>
+          ))}
         </nav>
-        <a className="btn" href={messengerUrl} target="_blank" rel="noreferrer">
-          Message Us
-        </a>
+        <div className="header-actions">
+          <button
+            type="button"
+            className="theme-toggle"
+            onClick={onToggleTheme}
+            aria-pressed={theme === 'light'}
+            aria-label="Toggle color theme"
+          >
+            <span aria-hidden="true" className="theme-toggle-icon">
+              {theme === 'light' ? '☀️' : '🌙'}
+            </span>
+            <span>{theme === 'light' ? 'Light' : 'Dark'} Mode</span>
+          </button>
+          <a className="btn header-cta" href={messengerUrl} target="_blank" rel="noreferrer">
+            Message Us
+          </a>
+          <button
+            type="button"
+            className="menu-toggle"
+            aria-expanded={menuOpen}
+            aria-controls="mobile-navigation"
+            onClick={() => setMenuOpen((prev) => !prev)}
+          >
+            <span />
+            <span />
+            <span />
+            <span className="sr-only">Toggle navigation</span>
+          </button>
+        </div>
+      </div>
+      <div id="mobile-navigation" className={`mobile-nav${menuOpen ? ' open' : ''}`} aria-hidden={!menuOpen}>
+        <div className="mobile-nav-links">
+          {navLinks.map(({ to, label, end }) => (
+            <NavLink key={`mobile-${to}`} to={to} end={end}>
+              {label}
+            </NavLink>
+          ))}
+          <a className="btn" href={messengerUrl} target="_blank" rel="noreferrer">
+            Message Us
+          </a>
+        </div>
       </div>
     </header>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,13 +1,63 @@
 :root {
+  --max-width: 1200px;
+  --header-height: 72px;
   --color-bg: #0f0f10;
   --color-surface: #171717;
+  --color-surface-muted: rgba(23, 23, 23, 0.85);
   --color-text: #ececec;
   --color-muted: #a0a0a0;
   --color-accent: #c5a572;
   --color-accent-2: #f7f6f3;
-  --max-width: 1200px;
-  --header-height: 72px;
+  --color-border: rgba(255, 255, 255, 0.08);
+  --color-border-soft: rgba(255, 255, 255, 0.05);
+  --color-header-bg: rgba(15, 15, 16, 0.9);
+  --color-header-border: rgba(255, 255, 255, 0.05);
+  --color-footer-bg: #101011;
+  --color-sticky-bg: rgba(23, 23, 23, 0.85);
+  --color-sticky-border: rgba(197, 165, 114, 0.35);
+  --color-card-gradient-1: rgba(197, 165, 114, 0.2);
+  --color-card-gradient-2: rgba(15, 15, 16, 0.4);
+  --color-hero-glow-1: rgba(197, 165, 114, 0.15);
+  --color-hero-glow-2: rgba(247, 246, 243, 0.08);
+  --color-btn-text: #0f0f10;
+  --color-accent-soft: rgba(197, 165, 114, 0.12);
+  --shadow-card: 0 15px 40px rgba(0, 0, 0, 0.25);
+  --shadow-card-hover: 0 20px 50px rgba(0, 0, 0, 0.35);
+  --shadow-floating: 0 20px 40px rgba(0, 0, 0, 0.45);
+  --shadow-accent: 0 10px 30px rgba(197, 165, 114, 0.25);
+  --shadow-accent-hover: 0 12px 40px rgba(197, 165, 114, 0.35);
   font-size: 16px;
+}
+
+body[data-theme='dark'] {
+  color-scheme: dark;
+}
+
+body[data-theme='light'] {
+  --color-bg: #faf9f7;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f2f1ee;
+  --color-text: #1c1c1e;
+  --color-muted: #6b6f76;
+  --color-accent: #c5a572;
+  --color-accent-2: #2c2a29;
+  --color-border: #e5e7eb;
+  --color-border-soft: rgba(229, 231, 235, 0.7);
+  --color-header-bg: rgba(250, 249, 247, 0.9);
+  --color-header-border: rgba(229, 231, 235, 0.8);
+  --color-footer-bg: #f2f1ee;
+  --color-sticky-bg: rgba(255, 255, 255, 0.95);
+  --color-sticky-border: rgba(197, 165, 114, 0.35);
+  --color-card-gradient-1: rgba(197, 165, 114, 0.22);
+  --color-card-gradient-2: rgba(44, 42, 41, 0.08);
+  --color-hero-glow-1: rgba(197, 165, 114, 0.18);
+  --color-hero-glow-2: rgba(44, 42, 41, 0.05);
+  --color-btn-text: #2c2a29;
+  --color-accent-soft: rgba(197, 165, 114, 0.2);
+  --shadow-card: 0 15px 40px rgba(44, 42, 41, 0.12);
+  --shadow-card-hover: 0 20px 50px rgba(44, 42, 41, 0.18);
+  --shadow-floating: 0 20px 40px rgba(44, 42, 41, 0.16);
+  color-scheme: light;
 }
 
 * {
@@ -20,6 +70,7 @@ body {
   background: var(--color-bg);
   color: var(--color-text);
   min-height: 100vh;
+  transition: background 0.25s ease, color 0.25s ease;
 }
 
 a {
@@ -39,10 +90,11 @@ main {
 header {
   position: sticky;
   top: 0;
-  z-index: 100;
-  background: rgba(15, 15, 16, 0.9);
-  backdrop-filter: blur(10px);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  z-index: 120;
+  background: var(--color-header-bg);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--color-header-border);
+  transition: background 0.25s ease, border-color 0.25s ease;
 }
 
 .header-inner {
@@ -51,7 +103,7 @@ header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 1.5rem;
+  padding: 0.85rem clamp(1rem, 3vw, 1.75rem);
   gap: 1rem;
 }
 
@@ -62,23 +114,175 @@ header {
   text-transform: uppercase;
   color: var(--color-accent);
   font-size: 1rem;
+  white-space: nowrap;
 }
 
-nav {
+.nav-links {
   display: flex;
   gap: 1.5rem;
   align-items: center;
 }
 
-nav a {
+.nav-links a {
   font-size: 0.95rem;
   color: var(--color-muted);
   transition: color 0.2s ease;
+  font-weight: 500;
 }
 
-nav a.active,
-nav a:hover {
+.nav-links a.active,
+.nav-links a:hover {
   color: var(--color-accent);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-muted);
+  color: var(--color-text);
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+  background: var(--color-surface);
+  border-color: var(--color-border);
+  outline: none;
+}
+
+.theme-toggle-icon {
+  font-size: 1rem;
+}
+
+.menu-toggle {
+  display: none;
+  position: relative;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-muted);
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.menu-toggle span {
+  display: block;
+  width: 18px;
+  height: 2px;
+  background: var(--color-text);
+  border-radius: 999px;
+  margin: 2px 0;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.menu-toggle[aria-expanded='true'] span:nth-of-type(1) {
+  transform: translateY(4px) rotate(45deg);
+}
+
+.menu-toggle[aria-expanded='true'] span:nth-of-type(2) {
+  opacity: 0;
+}
+
+.menu-toggle[aria-expanded='true'] span:nth-of-type(3) {
+  transform: translateY(-4px) rotate(-45deg);
+}
+
+.menu-toggle:hover,
+.menu-toggle:focus-visible {
+  background: var(--color-surface);
+  border-color: var(--color-border);
+  outline: none;
+}
+
+.header-cta {
+  white-space: nowrap;
+}
+
+.mobile-nav {
+  position: fixed;
+  inset: calc(var(--header-height) + 0.75rem) 1rem auto;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  box-shadow: var(--shadow-floating);
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  transform: translateY(-10px);
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+  z-index: 140;
+}
+
+.mobile-nav.open {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+  visibility: visible;
+}
+
+@media (min-width: 901px) {
+  .mobile-nav {
+    display: none;
+  }
+}
+
+.mobile-nav-links {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.mobile-nav-links a {
+  padding: 0.75rem 0.5rem;
+  border-bottom: 1px solid var(--color-border-soft);
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.mobile-nav-links a.active {
+  color: var(--color-accent);
+}
+
+.mobile-nav-links a.btn {
+  border: none;
+  padding: 0;
+  justify-content: center;
+}
+
+.mobile-nav .btn {
+  width: 100%;
+  margin-top: 0.5rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .btn {
@@ -90,16 +294,16 @@ nav a:hover {
   font-weight: 600;
   font-family: 'Poppins', sans-serif;
   background: linear-gradient(135deg, var(--color-accent), #efcf93);
-  color: #0f0f10;
+  color: var(--color-btn-text);
   border: none;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 10px 30px rgba(197, 165, 114, 0.25);
+  box-shadow: var(--shadow-accent);
 }
 
 .btn:hover {
   transform: translateY(-2px);
-  box-shadow: 0 12px 40px rgba(197, 165, 114, 0.35);
+  box-shadow: var(--shadow-accent-hover);
 }
 
 .btn-outline {
@@ -118,19 +322,19 @@ nav a:hover {
 }
 
 .btn-outline:hover {
-  background: rgba(197, 165, 114, 0.1);
+  background: var(--color-accent-soft);
 }
 
 .container {
   width: min(100%, var(--max-width));
   margin: 0 auto;
-  padding: 0 1.5rem;
+  padding: 0 clamp(1rem, 5vw, 1.5rem);
 }
 
 .hero {
   padding: calc(var(--header-height) + 3rem) 0 4rem;
-  background: radial-gradient(circle at top left, rgba(197, 165, 114, 0.15), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(247, 246, 243, 0.08), transparent 45%);
+  background: radial-gradient(circle at top left, var(--color-hero-glow-1), transparent 55%),
+    radial-gradient(circle at bottom right, var(--color-hero-glow-2), transparent 45%);
 }
 
 .hero h1 {
@@ -174,14 +378,14 @@ nav a:hover {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.25);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: var(--shadow-card);
+  border: 1px solid var(--color-border-soft);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .card:hover {
   transform: translateY(-4px);
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+  box-shadow: var(--shadow-card-hover);
 }
 
 .card-header {
@@ -189,7 +393,7 @@ nav a:hover {
   border-radius: 12px;
   overflow: hidden;
   aspect-ratio: 4 / 3;
-  background: linear-gradient(135deg, rgba(197, 165, 114, 0.2), rgba(15, 15, 16, 0.4));
+  background: linear-gradient(135deg, var(--color-card-gradient-1), var(--color-card-gradient-2));
 }
 
 .card-header img {
@@ -210,7 +414,7 @@ nav a:hover {
   text-transform: uppercase;
   padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  background: rgba(197, 165, 114, 0.12);
+  background: var(--color-accent-soft);
   color: var(--color-accent);
 }
 
@@ -222,9 +426,10 @@ nav a:hover {
 }
 
 footer {
-  background: #101011;
+  background: var(--color-footer-bg);
   padding: 3rem 0 2rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  border-top: 1px solid var(--color-border);
+  transition: background 0.25s ease, border-color 0.25s ease;
 }
 
 .footer-grid {
@@ -271,7 +476,7 @@ footer {
   border-radius: 14px;
   height: 320px;
   object-fit: cover;
-  background: linear-gradient(135deg, rgba(197, 165, 114, 0.15), rgba(15, 15, 16, 0.6));
+  background: linear-gradient(135deg, var(--color-card-gradient-1), var(--color-card-gradient-2));
 }
 
 .gallery button {
@@ -293,8 +498,8 @@ footer {
   gap: 1rem;
   padding: 1rem 1.25rem;
   border-radius: 12px;
-  background: rgba(23, 23, 23, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.04);
+  background: var(--color-surface-muted);
+  border: 1px solid var(--color-border-soft);
 }
 
 .table-like span:first-child {
@@ -302,14 +507,14 @@ footer {
 }
 
 .filter-bar {
-  background: rgba(23, 23, 23, 0.75);
+  background: var(--color-surface-muted);
   padding: 1.5rem;
   border-radius: 16px;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 1rem;
   margin-bottom: 2rem;
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--color-border-soft);
 }
 
 .filter-bar label {
@@ -326,8 +531,8 @@ footer {
 .filter-bar input {
   padding: 0.65rem 0.75rem;
   border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  background: rgba(15, 15, 16, 0.85);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
   color: var(--color-text);
   font-size: 0.95rem;
 }
@@ -350,7 +555,7 @@ footer {
   border-radius: 18px;
   display: grid;
   gap: 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--color-border-soft);
 }
 
 .contact-actions {
@@ -362,7 +567,7 @@ footer {
 .list-empty {
   padding: 2rem;
   border-radius: 16px;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--color-surface-muted);
   text-align: center;
   color: var(--color-muted);
 }
@@ -371,7 +576,7 @@ footer {
   margin: 4rem 0;
   padding: 3rem;
   border-radius: 20px;
-  background: linear-gradient(135deg, rgba(197, 165, 114, 0.25), rgba(15, 15, 16, 0.8));
+  background: linear-gradient(135deg, var(--color-card-gradient-1), var(--color-surface-muted));
   text-align: center;
   display: grid;
   gap: 1rem;
@@ -394,14 +599,14 @@ footer {
   bottom: 1rem;
   left: 50%;
   transform: translateX(-50%);
-  background: rgba(23, 23, 23, 0.85);
-  border: 1px solid rgba(197, 165, 114, 0.35);
+  background: var(--color-sticky-bg);
+  border: 1px solid var(--color-sticky-border);
   padding: 0.75rem 1rem;
   border-radius: 999px;
   display: none;
   gap: 0.75rem;
   z-index: 200;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+  box-shadow: var(--shadow-floating);
 }
 
 .cta-sticky a {
@@ -415,8 +620,8 @@ footer {
   bottom: 0;
   left: 0;
   right: 0;
-  background: rgba(15, 15, 16, 0.95);
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--color-surface-muted);
+  border-top: 1px solid var(--color-border);
   padding: 1rem 1.5rem;
   display: flex;
   flex-wrap: wrap;
@@ -435,7 +640,7 @@ footer {
   font-weight: 600;
   cursor: pointer;
   background: var(--color-accent);
-  color: #0f0f10;
+  color: var(--color-btn-text);
 }
 
 .admin-grid {
@@ -446,10 +651,11 @@ footer {
 
 .admin-panel,
 .admin-side {
-  background: rgba(23, 23, 23, 0.85);
+  background: var(--color-surface-muted);
   border-radius: 16px;
   padding: 1.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--color-border-soft);
+  transition: background 0.25s ease, border-color 0.25s ease;
 }
 
 .admin-list {
@@ -459,10 +665,10 @@ footer {
 
 .admin-list button {
   border-radius: 10px;
-  border: none;
+  border: 1px solid var(--color-border-soft);
   padding: 0.5rem 0.75rem;
   cursor: pointer;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--color-surface);
   color: var(--color-text);
 }
 
@@ -485,8 +691,8 @@ footer {
 .admin-form textarea {
   padding: 0.75rem;
   border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  background: rgba(15, 15, 16, 0.9);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
   color: var(--color-text);
   font-family: inherit;
 }
@@ -506,10 +712,10 @@ footer {
   margin: 4rem auto;
   padding: 2rem;
   border-radius: 18px;
-  background: rgba(23, 23, 23, 0.85);
+  background: var(--color-surface-muted);
   display: grid;
   gap: 1rem;
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--color-border-soft);
   text-align: center;
 }
 
@@ -519,32 +725,72 @@ footer {
   }
 }
 
-@media (max-width: 768px) {
-  nav {
+@media (max-width: 1024px) {
+  .header-cta {
     display: none;
+  }
+}
+
+@media (max-width: 900px) {
+  .nav-links {
+    display: none;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
+  }
+
+  .header-actions {
+    gap: 0.5rem;
+  }
+
+  .mobile-nav {
+    inset: calc(var(--header-height) + 0.75rem) clamp(1rem, 6vw, 1.5rem) auto;
+  }
+}
+
+@media (max-width: 768px) {
+  body {
+    font-size: 0.95rem;
   }
 
   .hero {
     padding-top: calc(var(--header-height) + 2rem);
   }
 
-  .cta-sticky {
-    display: flex;
+  .hero .container {
+    text-align: center;
   }
 
-  .header-inner {
-    justify-content: space-between;
-  }
-}
-
-@media (max-width: 540px) {
-  body {
-    font-size: 0.95rem;
+  .hero p {
+    margin: 0 auto;
   }
 
   .hero-actions {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .cta-sticky {
+    display: flex;
+  }
+
+  .theme-toggle {
+    padding: 0.4rem 0.75rem;
+  }
+}
+
+@media (max-width: 540px) {
+  body {
+    font-size: 0.9rem;
+  }
+
+  .hero h1 {
+    font-size: clamp(2.1rem, 9vw, 2.8rem);
+  }
+
+  .mobile-nav {
+    inset: calc(var(--header-height) + 0.5rem) 0.75rem auto;
   }
 
   .cta-sticky {


### PR DESCRIPTION
## Summary
- add persisted theme management so the site can switch between dark and new light palettes
- enhance the header with a theme toggle and mobile navigation menu for small screens
- refresh global styles to support light colors and improve spacing across mobile and tablet breakpoints

## Testing
- npm run build *(fails: vite not found because dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d52d6ffcdc8333870c324da65f0792