### PR TITLE
Adjust mobile menu toggle and restore page margins

### DIFF
--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -12,7 +12,7 @@ const About = () => {
   }, []);
 
   return (
-    <section className="container rich-text" style={{ padding: '4rem 0' }}>
+    <section className="container rich-text" style={{ paddingBlock: '4rem' }}>
       <h1 className="section-title">Our Family Legacy</h1>
       <p>
         Nacar Family Realty was born from decades of stewardship across Aklan&apos;s most promising parcels. What began as a

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -141,7 +141,7 @@ const AdminContent = ({ initialProperties }) => {
   const exportData = JSON.stringify(properties, null, 2);
 
   return (
-    <section className="container" style={{ padding: '4rem 0' }}>
+    <section className="container" style={{ paddingBlock: '4rem' }}>
       <h1 className="section-title">Admin: Manage Listings</h1>
       <div className="admin-grid">
         <div className="admin-panel">

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -12,7 +12,7 @@ const Contact = ({ messengerUrl }) => {
   }, []);
 
   return (
-    <section className="container" style={{ padding: '4rem 0' }}>
+    <section className="container" style={{ paddingBlock: '4rem' }}>
       <h1 className="section-title">Speak With Our Family Agent</h1>
       <div className="contact-card">
         <p>

--- a/src/pages/Cookies.jsx
+++ b/src/pages/Cookies.jsx
@@ -12,7 +12,7 @@ const Cookies = () => {
   }, []);
 
   return (
-    <section className="container rich-text" style={{ padding: '4rem 0' }}>
+    <section className="container rich-text" style={{ paddingBlock: '4rem' }}>
       <h1 className="section-title">Cookie Policy</h1>
       <p>Last updated: January 1, 2025</p>
       <p>

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -12,7 +12,7 @@ const Privacy = () => {
   }, []);
 
   return (
-    <section className="container rich-text" style={{ padding: '4rem 0' }}>
+    <section className="container rich-text" style={{ paddingBlock: '4rem' }}>
       <h1 className="section-title">Privacy Policy</h1>
       <p>Last updated: January 1, 2025</p>
       <p>

--- a/src/pages/Terms.jsx
+++ b/src/pages/Terms.jsx
@@ -12,7 +12,7 @@ const Terms = () => {
   }, []);
 
   return (
-    <section className="container rich-text" style={{ padding: '4rem 0' }}>
+    <section className="container rich-text" style={{ paddingBlock: '4rem' }}>
       <h1 className="section-title">Terms of Service</h1>
       <p>Last updated: January 1, 2025</p>
       <p>

--- a/src/styles.css
+++ b/src/styles.css
@@ -178,6 +178,8 @@ header {
   cursor: pointer;
   align-items: center;
   justify-content: center;
+  flex-direction: column;
+  gap: 0.35rem;
   padding: 0;
   transition: background 0.2s ease, border-color 0.2s ease;
 }
@@ -188,12 +190,12 @@ header {
   height: 2px;
   background: var(--color-text);
   border-radius: 999px;
-  margin: 2px 0;
+  margin: 0;
   transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
 .menu-toggle[aria-expanded='true'] span:nth-of-type(1) {
-  transform: translateY(4px) rotate(45deg);
+  transform: translateY(6px) rotate(45deg);
 }
 
 .menu-toggle[aria-expanded='true'] span:nth-of-type(2) {
@@ -201,7 +203,7 @@ header {
 }
 
 .menu-toggle[aria-expanded='true'] span:nth-of-type(3) {
-  transform: translateY(-4px) rotate(-45deg);
+  transform: translateY(-6px) rotate(-45deg);
 }
 
 .menu-toggle:hover,


### PR DESCRIPTION
## Summary
- align the mobile menu toggle bars vertically so the header shows a proper hamburger icon when collapsed
- use padding-block on informational sections so they retain the container's horizontal spacing on smaller screens

## Testing
- npm install *(fails: registry returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d5330e1ae08333b51de1d56abf84d5